### PR TITLE
fix: use null prototype for LayoutAnimationRepository config

### DIFF
--- a/src/reanimated2/layoutReanimation/LayoutAnimationRepository.ts
+++ b/src/reanimated2/layoutReanimation/LayoutAnimationRepository.ts
@@ -7,7 +7,7 @@ import { processColor } from '../Colors';
 runOnUI(() => {
   'worklet';
 
-  const configs: Record<string, any> = {};
+  const configs: Record<string, any> = Object.create(null);
   const enteringAnimationForTag: Record<string, any> = {};
 
   global.LayoutAnimationRepository = {


### PR DESCRIPTION
Prevent the `configs` object from having properties inherited from `Object.prototype`, such as `toString` or `__proto__`. Otherwise, using these properties could potentially have a security impact.