### PR TITLE
Fix ReDoS when parsing colors

### DIFF
--- a/src/reanimated2/Colors.ts
+++ b/src/reanimated2/Colors.ts
@@ -23,7 +23,7 @@ interface HSV {
 }
 
 // var INTEGER = '[-+]?\\d+';
-const NUMBER = '[-+]?\\d*\\.?\\d+';
+const NUMBER = '[-+]?\\d*(?:\\.\\d*)?';
 const PERCENTAGE = NUMBER + '%';
 
 function call(...args: unknown[]): string {


### PR DESCRIPTION
The regular expression used to parse numbers could be abused to cause a denial of service if the color to be parsed is controlled by an attacker.

Here is a proof-of-concept of how I made the existing regular expression cause a 100% CPU usage for several seconds, after being interrupted:

```
Welcome to Node.js v14.19.3.
Type ".help" for more information.
> (new RegExp('^[-+]?\\d*\\.?\\d+$')).test(`${'1'.repeat(1e6)}z`)
^CUncaught Error: Script execution was interrupted by `SIGINT`
    at Script.runInThisContext (vm.js:134:12)
    at REPLServer.defaultEval (repl.js:566:29)
    at bound (domain.js:421:15)
    at REPLServer.runBound [as eval] (domain.js:432:12)
    at REPLServer.onLine (repl.js:909:10)
    at REPLServer.emit (events.js:412:35)
    at REPLServer.emit (domain.js:475:12)
    at REPLServer.Interface._onLine (readline.js:434:10)
    at REPLServer.Interface._line (readline.js:791:8)
    at REPLServer.Interface._ttyWrite (readline.js:1136:14) {
  code: 'ERR_SCRIPT_EXECUTION_INTERRUPTED'
}
> (new RegExp('^[-+]?\\d*(?:\\.\\d*)?$')).test(`${'1'.repeat(1e6)}z`)
false
>
```

The new regex shouldn't be vulnerable because there's always only one possible path to take given any input.

For information about this vulnerability, see https://owasp.org/www-community/attacks/Regular_expression_Denial_of_Service_-_ReDoS.