### PR TITLE
Hardenize function sharing between JS runtimes

### DIFF
--- a/Common/cpp/Registries/WorkletsCache.cpp
+++ b/Common/cpp/Registries/WorkletsCache.cpp
@@ -6,14 +6,6 @@ using namespace facebook;
 
 namespace reanimated {
 
-jsi::Value eval(jsi::Runtime &rt, const char *code) {
-  return rt.global().getPropertyAsFunction(rt, "eval").call(rt, code);
-}
-
-jsi::Function function(jsi::Runtime &rt, const std::string &code) {
-  return eval(rt, ("(" + code + ")").c_str()).getObject(rt).getFunction(rt);
-}
-
 std::shared_ptr<jsi::Function> WorkletsCache::getFunction(
     jsi::Runtime &rt,
     std::shared_ptr<FrozenObject> frozenObj) {
@@ -22,7 +14,7 @@ std::shared_ptr<jsi::Function> WorkletsCache::getFunction(
   if (worklets.count(workletHash) == 0) {
     auto codeBuffer = std::make_shared<const jsi::StringBuffer>(
         "(" +
-        ValueWrapper::asString(frozenObj->map["asString"]->valueContainer) +
+        ValueWrapper::asString(frozenObj->map["__reanimated_workletFunction"]->valueContainer) +
         ")");
     auto func = rt.evaluateJavaScript(
                       codeBuffer,

--- a/Common/cpp/SharedItems/FrozenObject.cpp
+++ b/Common/cpp/SharedItems/FrozenObject.cpp
@@ -5,6 +5,18 @@
 
 namespace reanimated {
 
+jsi::Value functionToString(jsi::Runtime &rt, const jsi::Function &obj) {
+  jsi::Function toString = rt.global()
+      .getPropertyAsObject(rt, "Function")
+      .getPropertyAsObject(rt, "prototype")
+      .getPropertyAsFunction(rt, "toString");
+  jsi::Value code = toString.callWithThis(rt, obj);
+  if (!code.isString()) {
+      throw jsi::JSError(rt, "toString() return value isn't a string");
+  }
+  return code;
+}
+
 FrozenObject::FrozenObject(
     jsi::Runtime &rt,
     const jsi::Object &object,
@@ -16,9 +28,17 @@ FrozenObject::FrozenObject(
     auto propertyName = propertyNames.getValueAtIndex(rt, i).asString(rt);
     namesOrder.push_back(propertyName.utf8(rt));
     std::string nameStr = propertyName.utf8(rt);
-    map[nameStr] = ShareableValue::adapt(
-        rt, object.getProperty(rt, propertyName), runtimeManager);
-    this->containsHostFunction |= map[nameStr]->containsHostFunction;
+    if (nameStr == "__reanimated_workletFunction") {
+        // Save the function's source code, not the function itself
+        jsi::Function workletFunction = object.getPropertyAsFunction(rt, "__reanimated_workletFunction");
+        jsi::Value code = functionToString(rt, workletFunction);
+        map["__reanimated_workletFunction"] = ShareableValue::adapt(
+            rt, code, runtimeManager);
+    } else {
+        map[nameStr] = ShareableValue::adapt(
+            rt, object.getProperty(rt, propertyName), runtimeManager);
+        this->containsHostFunction |= map[nameStr]->containsHostFunction;
+    }
   }
 }
 

--- a/Common/cpp/SharedItems/ShareableValue.cpp
+++ b/Common/cpp/SharedItems/ShareableValue.cpp
@@ -434,8 +434,8 @@ jsi::Value ShareableValue::toJSValue(jsi::Runtime &rt) {
           runtimeManager->scheduler->scheduleOnUI([=] {
             jsi::Runtime &rt = *runtimeManager->runtime.get();
             auto jsThis = createFrozenWrapper(rt, frozenObject).getObject(rt);
-            auto code =
-                jsThis.getProperty(rt, "asString").asString(rt).utf8(rt);
+            /* auto code = */
+            /*     jsThis.getProperty(rt, "asString").asString(rt).utf8(rt); */
             std::shared_ptr<jsi::Function> funPtr(
                 runtimeManager->workletsCache->getFunction(rt, frozenObject));
 

--- a/__tests__/__snapshots__/plugin.test.js.snap
+++ b/__tests__/__snapshots__/plugin.test.js.snap
@@ -19,7 +19,18 @@ var f = function () {
       x: objX.x
     }
   };
-  _f.asString = \\"function f(){const{x,objX}=jsThis._closure;{return{res:x+objX.x};}}\\";
+
+  _f.__reanimated_workletFunction = function f() {
+    var _jsThis$_closure = jsThis._closure,
+        x = _jsThis$_closure.x,
+        objX = _jsThis$_closure.objX;
+    {
+      return {
+        res: x + objX.x
+      };
+    }
+  };
+
   _f.__workletHash = 10184269015616;
   _f.__location = \\"${ process.cwd() }/jest tests fixture (6:6)\\";
 
@@ -36,7 +47,11 @@ exports[`babel plugin doesn't capture globals 1`] = `
   };
 
   _f._closure = {};
-  _f.asString = \\"function f(){console.log('test');}\\";
+
+  _f.__reanimated_workletFunction = function f() {
+    console.log('test');
+  };
+
   _f.__workletHash = 13298016111221;
   _f.__location = \\"${ process.cwd() }/jest tests fixture (2:6)\\";
 
@@ -60,7 +75,12 @@ exports[`babel plugin doesn't transform string literals 1`] = `
   };
 
   _f._closure = {};
-  _f.asString = \\"function foo(x){const bar='worklet';const baz=\\\\\\"worklet\\\\\\";}\\";
+
+  _f.__reanimated_workletFunction = function foo(x) {
+    var bar = 'worklet';
+    var baz = \\"worklet\\";
+  };
+
   _f.__workletHash = 9810417751380;
   _f.__location = \\"${ process.cwd() }/jest tests fixture (2:6)\\";
 
@@ -89,7 +109,18 @@ function Box() {
     _f._closure = {
       offset: offset
     };
-    _f.asString = \\"function _f(){const{offset}=jsThis._closure;{return{transform:[{translateX:offset.value*255}]};}}\\";
+
+    _f.__reanimated_workletFunction = function _f() {
+      var offset = jsThis._closure.offset;
+      {
+        return {
+          transform: [{
+            translateX: offset.value * 255
+          }]
+        };
+      }
+    };
+
     _f.__workletHash = 7114514849439;
     _f.__location = \\"${ process.cwd() }/jest tests fixture (10:48)\\";
     _f.__optimalization = 3;
@@ -116,7 +147,11 @@ exports[`babel plugin workletizes ArrowFunctionExpression 1`] = `
   };
 
   _f._closure = {};
-  _f.asString = \\"function _f(x){return x+2;}\\";
+
+  _f.__reanimated_workletFunction = function _f(x) {
+    return x + 2;
+  };
+
   _f.__workletHash = 11411090164019;
   _f.__location = \\"${ process.cwd() }/jest tests fixture (2:18)\\";
 
@@ -133,7 +168,11 @@ exports[`babel plugin workletizes FunctionDeclaration 1`] = `
   };
 
   _f._closure = {};
-  _f.asString = \\"function foo(x){return x+2;}\\";
+
+  _f.__reanimated_workletFunction = function foo(x) {
+    return x + 2;
+  };
+
   _f.__workletHash = 4679479961836;
   _f.__location = \\"${ process.cwd() }/jest tests fixture (2:6)\\";
 
@@ -165,7 +204,14 @@ var Foo = function () {
       _f._closure = {
         x: x
       };
-      _f.asString = \\"function get(){const{x}=jsThis._closure;{return x+2;}}\\";
+
+      _f.__reanimated_workletFunction = function get() {
+        var x = jsThis._closure.x;
+        {
+          return x + 2;
+        }
+      };
+
       _f.__workletHash = 2468276954688;
       _f.__location = \\"${ process.cwd() }/jest tests fixture\\";
 
@@ -187,7 +233,11 @@ exports[`babel plugin workletizes hook wrapped ArrowFunctionExpression automatic
   };
 
   _f._closure = {};
-  _f.asString = \\"function _f(){width:50;}\\";
+
+  _f.__reanimated_workletFunction = function _f() {
+    width: 50;
+  };
+
   _f.__workletHash = 5067980299705;
   _f.__location = \\"${ process.cwd() }/jest tests fixture (2:45)\\";
   _f.__optimalization = 3;
@@ -207,7 +257,13 @@ exports[`babel plugin workletizes hook wrapped named FunctionExpression automati
   };
 
   _f._closure = {};
-  _f.asString = \\"function foo(){return{width:50};}\\";
+
+  _f.__reanimated_workletFunction = function foo() {
+    return {
+      width: 50
+    };
+  };
+
   _f.__workletHash = 6275510763626;
   _f.__location = \\"${ process.cwd() }/jest tests fixture (2:45)\\";
   _f.__optimalization = 3;
@@ -227,7 +283,13 @@ exports[`babel plugin workletizes hook wrapped unnamed FunctionExpression automa
   };
 
   _f._closure = {};
-  _f.asString = \\"function _f(){return{width:50};}\\";
+
+  _f.__reanimated_workletFunction = function _f() {
+    return {
+      width: 50
+    };
+  };
+
   _f.__workletHash = 9756190407413;
   _f.__location = \\"${ process.cwd() }/jest tests fixture (2:45)\\";
   _f.__optimalization = 3;
@@ -258,7 +320,11 @@ var Foo = function () {
       };
 
       _f._closure = {};
-      _f.asString = \\"function bar(x){return x+2;}\\";
+
+      _f.__reanimated_workletFunction = function bar(x) {
+        return x + 2;
+      };
+
       _f.__workletHash = 16974800582491;
       _f.__location = \\"${ process.cwd() }/jest tests fixture\\";
 
@@ -278,7 +344,11 @@ exports[`babel plugin workletizes named FunctionExpression 1`] = `
   };
 
   _f._closure = {};
-  _f.asString = \\"function foo(x){return x+2;}\\";
+
+  _f.__reanimated_workletFunction = function foo(x) {
+    return x + 2;
+  };
+
   _f.__workletHash = 4679479961836;
   _f.__location = \\"${ process.cwd() }/jest tests fixture (2:18)\\";
 
@@ -296,7 +366,11 @@ exports[`babel plugin workletizes object hook wrapped ArrowFunctionExpression au
     };
 
     _f._closure = {};
-    _f.asString = \\"function _f(event){console.log(event);}\\";
+
+    _f.__reanimated_workletFunction = function _f(event) {
+      console.log(event);
+    };
+
     _f.__workletHash = 2164830539996;
     _f.__location = \\"${ process.cwd() }/jest tests fixture (3:17)\\";
 
@@ -315,7 +389,11 @@ exports[`babel plugin workletizes object hook wrapped ObjectMethod automatically
     };
 
     _f._closure = {};
-    _f.asString = \\"function onStart(event){console.log(event);}\\";
+
+    _f.__reanimated_workletFunction = function onStart(event) {
+      console.log(event);
+    };
+
     _f.__workletHash = 338158776260;
     _f.__location = \\"${ process.cwd() }/jest tests fixture (3:8)\\";
 
@@ -334,7 +412,11 @@ exports[`babel plugin workletizes object hook wrapped named FunctionExpression a
     };
 
     _f._closure = {};
-    _f.asString = \\"function onStart(event){console.log(event);}\\";
+
+    _f.__reanimated_workletFunction = function onStart(event) {
+      console.log(event);
+    };
+
     _f.__workletHash = 338158776260;
     _f.__location = \\"${ process.cwd() }/jest tests fixture (3:17)\\";
 
@@ -353,7 +435,11 @@ exports[`babel plugin workletizes object hook wrapped unnamed FunctionExpression
     };
 
     _f._closure = {};
-    _f.asString = \\"function _f(event){console.log(event);}\\";
+
+    _f.__reanimated_workletFunction = function _f(event) {
+      console.log(event);
+    };
+
     _f.__workletHash = 2164830539996;
     _f.__location = \\"${ process.cwd() }/jest tests fixture (3:17)\\";
 
@@ -373,7 +459,11 @@ var foo = _reactNativeGestureHandler.Gesture.Tap().numberOfTaps(2).onBegin(funct
   };
 
   _f._closure = {};
-  _f.asString = \\"function _f(){console.log('onBegin');}\\";
+
+  _f.__reanimated_workletFunction = function _f() {
+    console.log('onBegin');
+  };
+
   _f.__workletHash = 13662490049850;
   _f.__location = \\"${ process.cwd() }/jest tests fixture (6:17)\\";
 
@@ -386,7 +476,11 @@ var foo = _reactNativeGestureHandler.Gesture.Tap().numberOfTaps(2).onBegin(funct
   };
 
   _f._closure = {};
-  _f.asString = \\"function _f(_event){console.log('onStart');}\\";
+
+  _f.__reanimated_workletFunction = function _f(_event) {
+    console.log('onStart');
+  };
+
   _f.__workletHash = 16334902412526;
   _f.__location = \\"${ process.cwd() }/jest tests fixture (9:17)\\";
 
@@ -399,7 +493,11 @@ var foo = _reactNativeGestureHandler.Gesture.Tap().numberOfTaps(2).onBegin(funct
   };
 
   _f._closure = {};
-  _f.asString = \\"function _f(_event,_success){console.log('onEnd');}\\";
+
+  _f.__reanimated_workletFunction = function _f(_event, _success) {
+    console.log('onEnd');
+  };
+
   _f.__workletHash = 4053780716017;
   _f.__location = \\"${ process.cwd() }/jest tests fixture (12:15)\\";
 
@@ -429,7 +527,11 @@ var Foo = function () {
       };
 
       _f._closure = {};
-      _f.asString = \\"function bar(x){return x+2;}\\";
+
+      _f.__reanimated_workletFunction = function bar(x) {
+        return x + 2;
+      };
+
       _f.__workletHash = 16974800582491;
       _f.__location = \\"${ process.cwd() }/jest tests fixture\\";
 
@@ -449,7 +551,11 @@ exports[`babel plugin workletizes unnamed FunctionExpression 1`] = `
   };
 
   _f._closure = {};
-  _f.asString = \\"function _f(x){return x+2;}\\";
+
+  _f.__reanimated_workletFunction = function _f(x) {
+    return x + 2;
+  };
+
   _f.__workletHash = 11411090164019;
   _f.__location = \\"${ process.cwd() }/jest tests fixture (2:18)\\";
 

--- a/__tests__/__snapshots__/plugin.test.js.snap
+++ b/__tests__/__snapshots__/plugin.test.js.snap
@@ -19,18 +19,7 @@ var f = function () {
       x: objX.x
     }
   };
-
-  _f.__reanimated_workletFunction = function f() {
-    var _jsThis$_closure = jsThis._closure,
-        x = _jsThis$_closure.x,
-        objX = _jsThis$_closure.objX;
-    {
-      return {
-        res: x + objX.x
-      };
-    }
-  };
-
+  _f.__reanimated_workletFunction = eval(\\"(function f(){const{x,objX}=jsThis._closure;{return{res:x+objX.x};}})\\");
   _f.__workletHash = 10184269015616;
   _f.__location = \\"${ process.cwd() }/jest tests fixture (6:6)\\";
 
@@ -47,11 +36,7 @@ exports[`babel plugin doesn't capture globals 1`] = `
   };
 
   _f._closure = {};
-
-  _f.__reanimated_workletFunction = function f() {
-    console.log('test');
-  };
-
+  _f.__reanimated_workletFunction = eval(\\"(function f(){console.log('test');})\\");
   _f.__workletHash = 13298016111221;
   _f.__location = \\"${ process.cwd() }/jest tests fixture (2:6)\\";
 
@@ -75,12 +60,7 @@ exports[`babel plugin doesn't transform string literals 1`] = `
   };
 
   _f._closure = {};
-
-  _f.__reanimated_workletFunction = function foo(x) {
-    var bar = 'worklet';
-    var baz = \\"worklet\\";
-  };
-
+  _f.__reanimated_workletFunction = eval(\\"(function foo(x){const bar='worklet';const baz=\\\\\\"worklet\\\\\\";})\\");
   _f.__workletHash = 9810417751380;
   _f.__location = \\"${ process.cwd() }/jest tests fixture (2:6)\\";
 
@@ -109,18 +89,7 @@ function Box() {
     _f._closure = {
       offset: offset
     };
-
-    _f.__reanimated_workletFunction = function _f() {
-      var offset = jsThis._closure.offset;
-      {
-        return {
-          transform: [{
-            translateX: offset.value * 255
-          }]
-        };
-      }
-    };
-
+    _f.__reanimated_workletFunction = eval(\\"(function _f(){const{offset}=jsThis._closure;{return{transform:[{translateX:offset.value*255}]};}})\\");
     _f.__workletHash = 7114514849439;
     _f.__location = \\"${ process.cwd() }/jest tests fixture (10:48)\\";
     _f.__optimalization = 3;
@@ -147,11 +116,7 @@ exports[`babel plugin workletizes ArrowFunctionExpression 1`] = `
   };
 
   _f._closure = {};
-
-  _f.__reanimated_workletFunction = function _f(x) {
-    return x + 2;
-  };
-
+  _f.__reanimated_workletFunction = eval(\\"(function _f(x){return x+2;})\\");
   _f.__workletHash = 11411090164019;
   _f.__location = \\"${ process.cwd() }/jest tests fixture (2:18)\\";
 
@@ -168,11 +133,7 @@ exports[`babel plugin workletizes FunctionDeclaration 1`] = `
   };
 
   _f._closure = {};
-
-  _f.__reanimated_workletFunction = function foo(x) {
-    return x + 2;
-  };
-
+  _f.__reanimated_workletFunction = eval(\\"(function foo(x){return x+2;})\\");
   _f.__workletHash = 4679479961836;
   _f.__location = \\"${ process.cwd() }/jest tests fixture (2:6)\\";
 
@@ -204,14 +165,7 @@ var Foo = function () {
       _f._closure = {
         x: x
       };
-
-      _f.__reanimated_workletFunction = function get() {
-        var x = jsThis._closure.x;
-        {
-          return x + 2;
-        }
-      };
-
+      _f.__reanimated_workletFunction = eval(\\"(function get(){const{x}=jsThis._closure;{return x+2;}})\\");
       _f.__workletHash = 2468276954688;
       _f.__location = \\"${ process.cwd() }/jest tests fixture\\";
 
@@ -233,11 +187,7 @@ exports[`babel plugin workletizes hook wrapped ArrowFunctionExpression automatic
   };
 
   _f._closure = {};
-
-  _f.__reanimated_workletFunction = function _f() {
-    width: 50;
-  };
-
+  _f.__reanimated_workletFunction = eval(\\"(function _f(){width:50;})\\");
   _f.__workletHash = 5067980299705;
   _f.__location = \\"${ process.cwd() }/jest tests fixture (2:45)\\";
   _f.__optimalization = 3;
@@ -257,13 +207,7 @@ exports[`babel plugin workletizes hook wrapped named FunctionExpression automati
   };
 
   _f._closure = {};
-
-  _f.__reanimated_workletFunction = function foo() {
-    return {
-      width: 50
-    };
-  };
-
+  _f.__reanimated_workletFunction = eval(\\"(function foo(){return{width:50};})\\");
   _f.__workletHash = 6275510763626;
   _f.__location = \\"${ process.cwd() }/jest tests fixture (2:45)\\";
   _f.__optimalization = 3;
@@ -283,13 +227,7 @@ exports[`babel plugin workletizes hook wrapped unnamed FunctionExpression automa
   };
 
   _f._closure = {};
-
-  _f.__reanimated_workletFunction = function _f() {
-    return {
-      width: 50
-    };
-  };
-
+  _f.__reanimated_workletFunction = eval(\\"(function _f(){return{width:50};})\\");
   _f.__workletHash = 9756190407413;
   _f.__location = \\"${ process.cwd() }/jest tests fixture (2:45)\\";
   _f.__optimalization = 3;
@@ -320,11 +258,7 @@ var Foo = function () {
       };
 
       _f._closure = {};
-
-      _f.__reanimated_workletFunction = function bar(x) {
-        return x + 2;
-      };
-
+      _f.__reanimated_workletFunction = eval(\\"(function bar(x){return x+2;})\\");
       _f.__workletHash = 16974800582491;
       _f.__location = \\"${ process.cwd() }/jest tests fixture\\";
 
@@ -344,11 +278,7 @@ exports[`babel plugin workletizes named FunctionExpression 1`] = `
   };
 
   _f._closure = {};
-
-  _f.__reanimated_workletFunction = function foo(x) {
-    return x + 2;
-  };
-
+  _f.__reanimated_workletFunction = eval(\\"(function foo(x){return x+2;})\\");
   _f.__workletHash = 4679479961836;
   _f.__location = \\"${ process.cwd() }/jest tests fixture (2:18)\\";
 
@@ -366,11 +296,7 @@ exports[`babel plugin workletizes object hook wrapped ArrowFunctionExpression au
     };
 
     _f._closure = {};
-
-    _f.__reanimated_workletFunction = function _f(event) {
-      console.log(event);
-    };
-
+    _f.__reanimated_workletFunction = eval(\\"(function _f(event){console.log(event);})\\");
     _f.__workletHash = 2164830539996;
     _f.__location = \\"${ process.cwd() }/jest tests fixture (3:17)\\";
 
@@ -389,11 +315,7 @@ exports[`babel plugin workletizes object hook wrapped ObjectMethod automatically
     };
 
     _f._closure = {};
-
-    _f.__reanimated_workletFunction = function onStart(event) {
-      console.log(event);
-    };
-
+    _f.__reanimated_workletFunction = eval(\\"(function onStart(event){console.log(event);})\\");
     _f.__workletHash = 338158776260;
     _f.__location = \\"${ process.cwd() }/jest tests fixture (3:8)\\";
 
@@ -412,11 +334,7 @@ exports[`babel plugin workletizes object hook wrapped named FunctionExpression a
     };
 
     _f._closure = {};
-
-    _f.__reanimated_workletFunction = function onStart(event) {
-      console.log(event);
-    };
-
+    _f.__reanimated_workletFunction = eval(\\"(function onStart(event){console.log(event);})\\");
     _f.__workletHash = 338158776260;
     _f.__location = \\"${ process.cwd() }/jest tests fixture (3:17)\\";
 
@@ -435,11 +353,7 @@ exports[`babel plugin workletizes object hook wrapped unnamed FunctionExpression
     };
 
     _f._closure = {};
-
-    _f.__reanimated_workletFunction = function _f(event) {
-      console.log(event);
-    };
-
+    _f.__reanimated_workletFunction = eval(\\"(function _f(event){console.log(event);})\\");
     _f.__workletHash = 2164830539996;
     _f.__location = \\"${ process.cwd() }/jest tests fixture (3:17)\\";
 
@@ -459,11 +373,7 @@ var foo = _reactNativeGestureHandler.Gesture.Tap().numberOfTaps(2).onBegin(funct
   };
 
   _f._closure = {};
-
-  _f.__reanimated_workletFunction = function _f() {
-    console.log('onBegin');
-  };
-
+  _f.__reanimated_workletFunction = eval(\\"(function _f(){console.log('onBegin');})\\");
   _f.__workletHash = 13662490049850;
   _f.__location = \\"${ process.cwd() }/jest tests fixture (6:17)\\";
 
@@ -476,11 +386,7 @@ var foo = _reactNativeGestureHandler.Gesture.Tap().numberOfTaps(2).onBegin(funct
   };
 
   _f._closure = {};
-
-  _f.__reanimated_workletFunction = function _f(_event) {
-    console.log('onStart');
-  };
-
+  _f.__reanimated_workletFunction = eval(\\"(function _f(_event){console.log('onStart');})\\");
   _f.__workletHash = 16334902412526;
   _f.__location = \\"${ process.cwd() }/jest tests fixture (9:17)\\";
 
@@ -493,11 +399,7 @@ var foo = _reactNativeGestureHandler.Gesture.Tap().numberOfTaps(2).onBegin(funct
   };
 
   _f._closure = {};
-
-  _f.__reanimated_workletFunction = function _f(_event, _success) {
-    console.log('onEnd');
-  };
-
+  _f.__reanimated_workletFunction = eval(\\"(function _f(_event,_success){console.log('onEnd');})\\");
   _f.__workletHash = 4053780716017;
   _f.__location = \\"${ process.cwd() }/jest tests fixture (12:15)\\";
 
@@ -527,11 +429,7 @@ var Foo = function () {
       };
 
       _f._closure = {};
-
-      _f.__reanimated_workletFunction = function bar(x) {
-        return x + 2;
-      };
-
+      _f.__reanimated_workletFunction = eval(\\"(function bar(x){return x+2;})\\");
       _f.__workletHash = 16974800582491;
       _f.__location = \\"${ process.cwd() }/jest tests fixture\\";
 
@@ -551,11 +449,7 @@ exports[`babel plugin workletizes unnamed FunctionExpression 1`] = `
   };
 
   _f._closure = {};
-
-  _f.__reanimated_workletFunction = function _f(x) {
-    return x + 2;
-  };
-
+  _f.__reanimated_workletFunction = eval(\\"(function _f(x){return x+2;})\\");
   _f.__workletHash = 11411090164019;
   _f.__location = \\"${ process.cwd() }/jest tests fixture (2:18)\\";
 

--- a/plugin.js
+++ b/plugin.js
@@ -467,7 +467,7 @@ function makeWorklet(t, fun, fileName) {
         '=',
         t.memberExpression(privateFunctionId, t.identifier('__reanimated_workletFunction'), false),
         // t.stringLiteral(funString)
-        workletFunction
+        t.callExpression(t.identifier('eval'), [t.stringLiteral('(' + funString + ')')])
       )
     ),
     t.expressionStatement(

--- a/plugin.js
+++ b/plugin.js
@@ -312,7 +312,8 @@ function buildWorkletString(t, fun, closureVariables, name) {
     )
   );
 
-  return generate(workletFunction, { compact: true }).code;
+  const funString = generate(workletFunction, { compact: true }).code;
+  return { workletFunction, funString };
 }
 
 function makeWorkletName(t, fun) {
@@ -434,7 +435,7 @@ function makeWorklet(t, fun, fileName) {
   } else {
     funExpression = clone;
   }
-  const funString = buildWorkletString(
+  const { workletFunction, funString } = buildWorkletString(
     t,
     transformed.ast,
     variables,
@@ -464,8 +465,9 @@ function makeWorklet(t, fun, fileName) {
     t.expressionStatement(
       t.assignmentExpression(
         '=',
-        t.memberExpression(privateFunctionId, t.identifier('asString'), false),
-        t.stringLiteral(funString)
+        t.memberExpression(privateFunctionId, t.identifier('__reanimated_workletFunction'), false),
+        // t.stringLiteral(funString)
+        workletFunction
       )
     ),
     t.expressionStatement(

--- a/src/reanimated2/Easing.ts
+++ b/src/reanimated2/Easing.ts
@@ -319,7 +319,8 @@ function createChecker(
   }
   // use original worklet on UI side
   checkIfReaOne._closure = worklet._closure;
-  checkIfReaOne.asString = worklet.asString;
+  checkIfReaOne.__reanimated_workletFunction =
+    worklet.__reanimated_workletFunction;
   checkIfReaOne.__workletHash = worklet.__workletHash;
   checkIfReaOne.__location = worklet.__location;
   return checkIfReaOne;


### PR DESCRIPTION
Context:

* Reanimated 2 executes code in [worklets](https://docs.swmansion.com/react-native-reanimated/docs/fundamentals/worklets/) for performance reasons. This requires having different JS runtimes
* Data can be shared between runtimes by rewriting functions so they fetch the data from a custom `this` object
* To share functions between runtimes, they have to be serialized. This is done by saving the code of the worklet function from one side, and evaluating this code from the other runtime.

This approach introduces two threats that we can't easily get rid of:

* Functions have to be rewritten to work inside a worklet. This is done automatically with babel, and doesn't seem to present a big risk
* In some part of the code, there has to be an eval of a string to deserialize the function. If the string gets somehow attacker-controlled, this could have a critical impact in the application

This PR is focused into making it harder for attackers to control the string to be eval'ed. It doesn't totally remove the threat, but makes it reasonably unlikely to occur.

Before the changes, the code to be evaled was fetched by saving the code of the rewritten function into the `asString` attribute of each function. The attribute was statically included in the bundled JS. If an attacker was able to change the `asString` attribute of a function so it contained a malicious string, the code would get evaluated. Attackers could control the `asString` attribute by polluting the function prototype, or even if they pollute a single function's attribute (such as `Object.prototype.toString.asString`).

This PR changes how the code to be eval'ed is fetched. Now:

* The code of the rewritten function isn't stored as a string. Now it is a regular function, stored inside an attribute of the original function
* Instead of directly sharing the `asString` attribute between runtimes, the first runtime calls `Function.prototype.toString` to the worklet function and shares the returned string to the second runtime
* The second runtime will eval the previous string to build a usable worklet function

By doing this, eval will always be used with the result of `Function.prototype.toString.call(someFunc)`. Controlling that would require attackers to be able to build a function with malicious code. This, although possible, is considerably harder than just creating a malicious string. And in most cases, if attackers are already able to create malicious functions, they will be able to get code execution even without using this attack vector.

Another way of attacking the current (and also the new) implementation would be that attackers don't create a malicious function, but instead they reuse a function that already exists on the codebase, but isn't expected to be used in a new context. This is similar to how a ROP chain works. I had the idea to hardenize this even more by cryptografically signing the code to be eval'ed, but due to the threat of code reuse I thought it wasn't worth the trouble. 