### PR TITLE
remove _WORKLET_RUNTIME global property

### DIFF
--- a/android/src/main/cpp/NativeProxy.cpp
+++ b/android/src/main/cpp/NativeProxy.cpp
@@ -165,19 +165,6 @@ void NativeProxy::installJSIBindings() {
   std::shared_ptr<jsi::Runtime> animatedRuntime =
       facebook::jsc::makeJSCRuntime();
 #endif
-  auto workletRuntimeValue =
-      runtime_->global()
-          .getProperty(*runtime_, "ArrayBuffer")
-          .asObject(*runtime_)
-          .asFunction(*runtime_)
-          .callAsConstructor(*runtime_, {static_cast<double>(sizeof(void *))});
-  uintptr_t *workletRuntimeData = reinterpret_cast<uintptr_t *>(
-      workletRuntimeValue.getObject(*runtime_).getArrayBuffer(*runtime_).data(
-          *runtime_));
-  workletRuntimeData[0] = reinterpret_cast<uintptr_t>(animatedRuntime.get());
-
-  runtime_->global().setProperty(
-      *runtime_, "_WORKLET_RUNTIME", workletRuntimeValue);
 
   auto version = getReanimatedVersionString(*runtime_);
   runtime_->global().setProperty(*runtime_, "_REANIMATED_VERSION_CPP", version);

--- a/ios/native/REAInitializer.mm
+++ b/ios/native/REAInitializer.mm
@@ -46,16 +46,6 @@ JSIExecutor::RuntimeInstaller REAJSIExecutorRuntimeInstaller(
     auto callInvoker = std::make_shared<react::BridgeJSCallInvoker>(bridge.reactInstance);
     auto reanimatedModule = reanimated::createReanimatedModule(bridge, callInvoker);
 #endif
-    auto workletRuntimeValue = runtime.global()
-                                   .getProperty(runtime, "ArrayBuffer")
-                                   .asObject(runtime)
-                                   .asFunction(runtime)
-                                   .callAsConstructor(runtime, {static_cast<double>(sizeof(void *))});
-    uintptr_t *workletRuntimeData =
-        reinterpret_cast<uintptr_t *>(workletRuntimeValue.getObject(runtime).getArrayBuffer(runtime).data(runtime));
-    workletRuntimeData[0] = reinterpret_cast<uintptr_t>(reanimatedModule->runtime.get());
-
-    runtime.global().setProperty(runtime, "_WORKLET_RUNTIME", workletRuntimeValue);
 
     auto version = getReanimatedVersionString(runtime);
     runtime.global().setProperty(runtime, "_REANIMATED_VERSION_CPP", version);


### PR DESCRIPTION
It exposed a memory pointer to the JS runtime. Leaking a memory address could potentially be used to exploit memory corruption bugs. For example, it's useful to defeat ASLR.

Also, it wrote data to an ArrayBuffer without checking the array length, which may cause out-of-bounds memory writes.