### PR TITLE
fix: load correct prod version of hermes & use any cmake version

### DIFF
--- a/packages/react-native-reanimated/android/build.gradle
+++ b/packages/react-native-reanimated/android/build.gradle
@@ -518,7 +518,12 @@ dependencies {
 
     implementation "com.facebook.react:react-android" // version substituted by RNGP
     if (JS_RUNTIME == "hermes") {
-        implementation "com.facebook.react:hermes-android" // version substituted by RNGP
+        if (System.getenv("BUILD_TYPE") == "release") {
+          def hermesPath = "../../@exodus/hermes-engine/android/";
+          releaseImplementation files(hermesPath + "hermes-release.aar")
+        } else {
+          implementation("com.facebook.react:hermes-android")
+        }
     }
 }
 

--- a/packages/react-native-reanimated/android/build.gradle
+++ b/packages/react-native-reanimated/android/build.gradle
@@ -270,7 +270,10 @@ android {
     }
     externalNativeBuild {
         cmake {
-            version = System.getenv("CMAKE_VERSION") ?: "3.22.1"
+            // We'll let the build system to resolve the version of CMake
+            // but keeping this here as a reminder that you should actually
+            // match the version being used in the React Native repo
+            // version = System.getenv("CMAKE_VERSION") ?: "3.22.1"
             path "CMakeLists.txt"
         }
     }

--- a/packages/react-native-reanimated/android/build.gradle
+++ b/packages/react-native-reanimated/android/build.gradle
@@ -522,7 +522,7 @@ dependencies {
     implementation "com.facebook.react:react-android" // version substituted by RNGP
     if (JS_RUNTIME == "hermes") {
         if (System.getenv("BUILD_TYPE") == "release") {
-          def hermesPath = "../../@exodus/hermes-engine/android/";
+          def hermesPath = "../../../@exodus/hermes-engine/android/";
           releaseImplementation files(hermesPath + "hermes-release.aar")
         } else {
           implementation("com.facebook.react:hermes-android")


### PR DESCRIPTION
## Summary

1. We should load the custom hermes build for inclusion during prod builds.
2. Let's drop the cmake version requirements for now, seems like nobody is building with 3.22.1 in our org, seems a bit of everything lol, let's roll the dice with that one.

