### PR TITLE
fix: runtime crash & compilation for prod hermes engine

### DIFF
--- a/packages/react-native-reanimated/Common/cpp/worklets/SharedItems/Shareables.cpp
+++ b/packages/react-native-reanimated/Common/cpp/worklets/SharedItems/Shareables.cpp
@@ -282,7 +282,12 @@ jsi::Value ShareableWorklet::toJSValue(jsi::Runtime &rt) {
   auto code = std::make_shared<const jsi::StringBuffer>(
       "(" + initData.getProperty(rt, "__reanimated_workletCode").asString(rt).utf8(rt) + "\n)");
 
-  auto sourceURL = initData.getProperty(rt, "location").asString(rt).utf8(rt);
+  std::string sourceURL = "unknown.js";
+  auto locationValue = initData.getProperty(rt, "location");
+  if (locationValue.isString()) {
+    sourceURL = locationValue.asString(rt).utf8(rt);
+  }
+
   // The code has to be evaluated in the context of the worklet runtime.
   // This is done by creating a new function that evaluates the code and
   // returns the resulting function.

--- a/packages/react-native-reanimated/android/build.gradle
+++ b/packages/react-native-reanimated/android/build.gradle
@@ -273,7 +273,7 @@ android {
             // We'll let the build system to resolve the version of CMake
             // but keeping this here as a reminder that you should actually
             // match the version being used in the React Native repo
-            // version = System.getenv("CMAKE_VERSION") ?: "3.22.1"
+            version = System.getenv("CMAKE_VERSION") ?: "3.22.1"
             path "CMakeLists.txt"
         }
     }

--- a/packages/react-native-reanimated/android/build.gradle
+++ b/packages/react-native-reanimated/android/build.gradle
@@ -522,10 +522,13 @@ dependencies {
     implementation "com.facebook.react:react-android" // version substituted by RNGP
     if (JS_RUNTIME == "hermes") {
         if (System.getenv("BUILD_TYPE") == "release") {
+          // Worklets compilation requires the hermes-engine headers
+          // swap out the hermes-engine with our own prebuilt version
+          // for release builds.
           def hermesPath = "../../../@exodus/hermes-engine/android/";
-          releaseImplementation files(hermesPath + "hermes-release.aar")
+          compileOnly files(hermesPath + "hermes-release.aar")
         } else {
-          implementation("com.facebook.react:hermes-android")
+          compileOnly("com.facebook.react:hermes-android")
         }
     }
 }


### PR DESCRIPTION
## Summary

Fixes the compilation procedure & runtime crashes for production builds.

* [fix: mark hermes-engine as a compileOnly dependency](https://github.com/ExodusMovement/react-native-reanimated/commit/c32c6e9e92c273f2941f42028340adadf84889d5) 
* [fix: prevent crash when no sourceURL](https://github.com/ExodusMovement/react-native-reanimated/commit/49fa5cfb87fb620f0c0457ecc78b4efe60259161)
* [fix: cmake 3.22.1 minimum is required](https://github.com/ExodusMovement/react-native-reanimated/commit/f5631cc42446dce6c93dc9ae61e4f5e6e859b737)

## Test plan

- [x] Android: works with https://github.com/ExodusMovement/hermes/pull/5 applied
- [x] iOS: works 
