### PR TITLE
fix: skia crash

### DIFF
--- a/packages/react-native-reanimated/Common/cpp/worklets/SharedItems/Shareables.cpp
+++ b/packages/react-native-reanimated/Common/cpp/worklets/SharedItems/Shareables.cpp
@@ -56,7 +56,7 @@ jsi::Value makeShareableClone(
   if (value.isObject()) {
     auto object = value.asObject(rt);
     jsi::PropNameID prop = workletCodePropName(rt);
-    if (object.hasProperty(rt, prop)) {
+    if (object.hasProperty(rt, prop) && object.getPropertyNames(rt).length(rt) == 0) {
       jsi::Value code = object.getProperty(rt, prop);
       shareable = std::make_shared<ShareableString>(code.asString(rt).utf8(rt));
     } else if (!object.getProperty(rt, "__workletHash").isUndefined()) {


### PR DESCRIPTION
## Summary

Skia has some advanced integration with reanimated. `__reanimated_workletCode` is somewhere attached to the already UI runtime compatible skia code. Which causes our code misbehave. I added additional check to make sure worklet code is only property in the object.  

@kewde will know much better but this trick fixes the problem